### PR TITLE
"dot set": スペースを含むパスを正しく扱えるようにする

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -126,6 +126,31 @@ bd_() { #{{{
 
 cleanup_namespace() { #{{{
   unset -f dotbundle get_fullpath path_without_home path_without_dotdir
-  unset -f __confirm prmpt bd_ dot_usage $0
+  unset -f __confirm prmpt bd_ dot_usage parse_linkfiles $0
 } #}}}
 
+parse_linkfiles() { # {{{
+  local linkfile l
+  local command
+  
+  command="$1"
+
+  for linkfile in "${linkfiles[@]}"; do
+    echo "$(prmpt 4 "Loading ${linkfile} ...")"
+
+    grep -Ev '^\s*#|^\s*$' "${linkfile}" | while read l; do
+      # extract environment variables
+      dotfile="$(echo $l | cut -d, -f1)"
+      dotfile="$(eval echo ${dotfile})"
+      orig="$(echo $l | cut -d, -f2)"
+      orig="$(eval echo ${orig})"
+      
+      # path completion
+      [ "${dotfile:0:1}" = "/" ] || dotfile="${dotdir}/$dotfile"
+      [ "${orig:0:1}" = "/" ] || orig="$HOME/$orig"
+
+      eval $command \"$dotfile\" \"$orig\"
+    done
+  done
+
+} # }}}

--- a/lib/dot_check.sh
+++ b/lib/dot_check.sh
@@ -1,19 +1,11 @@
 # vim: ft=sh
 dot_check() {
-  local linkfile l
 
   _dot_check() { #{{{
     local dotfile orig origdir linkto message
     local delimiter=","
-    # extract environment variables
-    dotfile="$(echo $1 | cut -d, -f1)"
-    dotfile="$(eval echo ${dotfile})"
-    orig="$(echo $1 | cut -d, -f2)"
-    orig="$(eval echo ${orig})"
-
-    # path completion
-    [ "${dotfile:0:1}" = "/" ] || dotfile="${dotdir}/$dotfile"
-    [ "${orig:0:1}" = "/" ] || orig="$HOME/$orig"
+    dotfile="$1"
+    orig="$2"
     message="${dotfile}${delimiter}${orig}"
 
     # if dotfile doesn't exist
@@ -31,14 +23,8 @@ dot_check() {
     fi
     return 0
   } #}}}
-
-  for linkfile in "${linkfiles[@]}"; do
-    echo "$(prmpt 4 "From ${linkfile}")"
-    while read l; do
-      _dot_check "$l"
-    done < <(grep -Ev '^\s*#|^\s*$' "${linkfile}")
-  done
+  
+  parse_linkfiles _dot_check
 
   unset -f _dot_check $0
-
 } 

--- a/lib/dot_clear.sh
+++ b/lib/dot_clear.sh
@@ -1,15 +1,10 @@
 # vim:ft=sh
 dot_clear() {
-  local linkfile l
 
   _dot_clear() { #{{{
     local orig
-
-    # extract environment variables
-    orig="$(eval echo $2)"
-
-    # path completion
-    [ "${orig:0:1}" = "/" ] || orig="$HOME/$orig"
+    
+    orig="$2"
 
     if [ -L "${orig}" ]; then
       unlink "${orig}"
@@ -17,12 +12,7 @@ dot_clear() {
     fi
   } #}}}
 
-  for linkfile in "${linkfiles[@]}"; do
-    echo "$(prmpt 4 "Loading ${linkfile} ...")"
-    while read l; do
-      _dot_clear $(echo $l | tr ',' ' ')
-    done < <(grep -Ev '^\s*#|^\s*$' "${linkfile}")
-  done
+  parse_linkfile _dot_clear
 
   unset -f _dot_clear $0
 }

--- a/lib/dot_list.sh
+++ b/lib/dot_list.sh
@@ -1,11 +1,8 @@
 # vim: ft=sh
 dot_list() {
-  local linkfile l
+  _dot_list() { echo $1,$2 }
 
-  for linkfile in "${linkfiles[@]}"; do
-    echo "$(prmpt 4 "From ${linkfile}")"
-    grep -Ev '^\s*#|^\s*$' "${linkfile}"
-  done
+  parse_linkfiles _dot_list
 
-  unset -f $0
+  unset -f _dot_list $0
 }

--- a/lib/dot_set.sh
+++ b/lib/dot_set.sh
@@ -1,7 +1,7 @@
 # vim: ft=sh
 dot_set() {
   # option handling
-  local linkfile l arg
+  local arg
   local dotset_ignore=false
   local dotset_force=false
   local dotset_backup=false
@@ -152,15 +152,8 @@ dot_set() {
 
   _dot_set() { #{{{
     local dotfile orig
-    # extract environment variables
-    dotfile="$(echo $1 | cut -d, -f1)"
-    dotfile="$(eval echo ${dotfile})"
-    orig="$(echo $1 | cut -d, -f2)"
-    orig="$(eval echo ${orig})"
-
-    # path completion
-    [ "${dotfile:0:1}" = "/" ] || dotfile="${dotdir}/$dotfile"
-    [ "${orig:0:1}" = "/" ] || orig="$HOME/$orig"
+    dotfile="$1"
+    orig="$2"
 
     # if dotfile doesn't exist, print error message and pass
     if [ ! -e "${dotfile}" ]; then
@@ -186,13 +179,7 @@ dot_set() {
 
   } #}}}
 
-  for linkfile in "${linkfiles[@]}"; do
-    echo "$(prmpt 4 "Loading ${linkfile} ...")"
-    while read l; do
-      _dot_set "$l"
-    done < <(grep -Ev '^\s*#|^\s*$' "${linkfile}")
-  done
+  parse_linkfiles _dot_set
 
   unset -f check_dir if_islink if_exist _dot_set replace replace_and_backup $0
-
 }

--- a/lib/dot_set.sh
+++ b/lib/dot_set.sh
@@ -153,8 +153,10 @@ dot_set() {
   _dot_set() { #{{{
     local dotfile orig
     # extract environment variables
-    dotfile="$(eval echo $1)"
-    orig="$(eval echo $2)"
+    dotfile="$(echo $1 | cut -d, -f1)"
+    dotfile="$(eval echo ${dotfile})"
+    orig="$(echo $1 | cut -d, -f2)"
+    orig="$(eval echo ${orig})"
 
     # path completion
     [ "${dotfile:0:1}" = "/" ] || dotfile="${dotdir}/$dotfile"
@@ -186,9 +188,9 @@ dot_set() {
 
   for linkfile in "${linkfiles[@]}"; do
     echo "$(prmpt 4 "Loading ${linkfile} ...")"
-    for l in $(grep -Ev '^\s*#|^\s*$' "${linkfile}"); do
-      _dot_set $(echo $l | tr ',' ' ')
-    done
+    while read l; do
+      _dot_set "$l"
+    done < <(grep -Ev '^\s*#|^\s*$' "${linkfile}")
   done
 
   unset -f check_dir if_islink if_exist _dot_set replace replace_and_backup $0


### PR DESCRIPTION
### Issue
- `dot set` がスペースを含むファイルを正しく扱えない
  - CSVのパース方法が `dot check` とは異なっていた
### Solution
- `dotlink` のパース方法を `dot check` に合わせた
- `dotlink` のパース処理を関数として抽出した
