### PR TITLE
lib/dot_set Fix #9

### DIFF
--- a/lib/dot_set.sh
+++ b/lib/dot_set.sh
@@ -59,9 +59,11 @@ dot_set() {
 
   replace_and_backup() { #{{{
     # replace_and_backup "${orig}" "${dotfile}"
-    ln -sb --suffix '.bak' "$2" "$1"
+    backuped="$1$(date +'_%Y%m%d_%H%M%S')"
+    mv -i "$1" "${backuped}"
+    ln -s "$2" "$1"
     echo "$(prmpt 2 done)$1"
-    echo "$(prmpt 2 "make backup")$1.bak"
+    echo "$(prmpt 2 "make backup")${backuped}"
   } #}}}
 
   if_islink() { #{{{


### PR DESCRIPTION
`ln -sb`でバックアップを作成してリンクを張り直す機能が、対象がディレクトリのとき期待した動作をしないため、ユニークな名前(タイムスタンプ)を末尾につけてバックアップとして保存した上でリンクを張り直す様に変更を加えた。

> #9 