### PR TITLE
Bashでdot listを使用出来るようにする

### DIFF
--- a/lib/dot_list.sh
+++ b/lib/dot_list.sh
@@ -1,6 +1,8 @@
 # vim: ft=sh
 dot_list() {
-  _dot_list() { echo $1,$2 }
+  _dot_list() {
+    echo $1,$2
+  }
 
   parse_linkfiles _dot_list
 


### PR DESCRIPTION
# 問題
bashで`dot list`を使うとsyntax errorになります。
```
$ dot list
~/.dot/lib/dot_list.sh: line 9: syntax error: unexpected end of file

$ bash -n ~/.dot/lib/dot_list.sh
~/.dot/lib/dot_list.sh: line 9: syntax error: unexpected end of file
```

# 変更点

bashで関数をワンライナーで記述する場合は以下のように`}`の前に`;`が必要です。
```
_dot_list() { echo $1,$2; }
```
上記のワンライナーでの修正でも問題ないですが、他の関数に合わせた形式で修正しています。

## before
```
_dot_list() { echo $1,$2 }
```
## after
```
_dot_list() {
  echo $1,$2
}
```

