### PR TITLE
fix of cant copy when link target was directory

### DIFF
--- a/lib/dot_unlink.sh
+++ b/lib/dot_unlink.sh
@@ -18,7 +18,7 @@ dot_unlink() {
     unlink "$currentpath"
 
     # copy the file
-    cp "$abspath" "$currentpath"
+    cp -r "$abspath" "$currentpath"
 
     echo "$(prmpt 1 unlink)$f"
     echo "$(prmpt 2 copy)$abspath"


### PR DESCRIPTION
ディレクトリをsetした後にunlinkでcp出来ていない現象を修正しました