### PR TITLE
Fix vertical bar display

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ Link relation table is in '[dotlink](./examples/dotlink)'.
 | [list](#dot_list)     | Show the list which files will be managed by dot.                                                             |                                                                       |
 | [check](#dot_check)   | Check the files are correctly linked to the right places.                                                     |                                                                       |
 | [cd](#dot_cd)         | Change directory to 'dotdir'.                                                                                 |                                                                       |
-| [set](#dot_set)       | Set symbolic links configured in `dotlink`.                                                                   | `[-i|--ignore][-f|--force][-b|--backup][-v|--verbose]`                |
-| [update](#dot_update) | Combined command of 'pull' and 'set' commands.                                                                | `[-i|--ignore][-f|--force][-b|--backup][-v|--verbose]`                |
+| [set](#dot_set)       | Set symbolic links configured in `dotlink`.                                                                   | `[-i\|--ignore][-f\|--force][-b\|--backup][-v\|--verbose]`            |
+| [update](#dot_update) | Combined command of 'pull' and 'set' commands.                                                                | `[-i\|--ignore][-f\|--force][-b\|--backup][-v\|--verbose]`            |
 | [add](#dot_add)       | Move the new file to the dotfile dir, make the link, and add the link information to `dotlink` automatically. | `some_file [$DOT_DIR/path/to/the/file]` or `link1 [link2 link3 ... ]` |
 | [edit](#dot_edit)     | Edit `dotlink`                                                                                                |                                                                       |
 | [config](#dot_config) | Edit configuration file 'dotrc'                                                                               |                                                                       |
 | [unlink](#dot_unlink) | Unlink the selected symbolic links and copy its original files from the dotfile directory.                    | `link1 [link2 link3 ... ]`                                            |
 | [clear](#dot_clear)   | Remove the *all* symbolic link written in the dotlink file `dotlink`.                                         |                                                                       |
-| [clone](#dot_clone)   | Clone dotfile repository on your computer with git.                                                           | `[-f|--force] [/directory/to/clone/]`                                 |
+| [clone](#dot_clone)   | Clone dotfile repository on your computer with git.                                                           | `[-f\|--force] [/directory/to/clone/]`                                |
 
 **option**
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -79,14 +79,14 @@ export DOT_DIR="$HOME/.dotfiles"
 | [list](#dot_list)     | `dot`で管理するファイルを一覧を表示                                                 |                                                                       |
 | [check](#dot_check)   | ファイルにリンクが張られているかどうかチェックする                                  |                                                                       |
 | [cd](#dot_cd)         | ディレクトリ`dotdir`に移動                                                          |                                                                       |
-| [set](#dot_set)       | `dotlink`に書かれたシンボリックリンクを貼る                                         | `[-i|--ignore][-f|--force][-b|--backup][-v|--verbose]`                |
-| [update](#dot_update) | 'pull'コマンドと'set'コマンドの組み合わせ                                           | `[-i|--ignore][-f|--force][-b|--backup][-v|--verbose]`                |
+| [set](#dot_set)       | `dotlink`に書かれたシンボリックリンクを貼る                                         | `[-i\|--ignore][-f\|--force][-b\|--backup][-v\|--verbose]`                |
+| [update](#dot_update) | 'pull'コマンドと'set'コマンドの組み合わせ                                           | `[-i\|--ignore][-f\|--force][-b\|--backup][-v\|--verbose]`                |
 | [add](#dot_add)       | 新たなファイルをdotfilesに追加，シンボリックリンクを貼り，対応関係を`dotlink`に追記 | `some_file [$DOT_DIR/path/to/the/file]` or `link1 [link2 link3 ... ]` |
 | [edit](#dot_edit)     | `dotlink`を手動で編集                                                               |                                                                       |
 | [config](#dot_config) | 設定ファイル`dotrc`を編集                                                           |                                                                       |
 | [unlink](#dot_unlink) | 選択したシンボリックリンクをunlinkし，dotfilesから元ファイルをコピー                | `link1 [link2 link3 ... ]`                                            |
 | [clear](#dot_clear)   | `dotlink`ファイルに記載された**すべての**シンボリックリンクをunlink                 |                                                                       |
-| [clone](#dot_clone)   | gitコマンドを使ってdotfilesを自分のPCにクローン                                     | `[-f|--force] [/directory/to/clone/]`                                 |
+| [clone](#dot_clone)   | gitコマンドを使ってdotfilesを自分のPCにクローン                                     | `[-f\|--force] [/directory/to/clone/]`                                 |
 
 **オプション**
 


### PR DESCRIPTION
readme.mdのTables内で「|」以降が表示されなくなっていたため、「|」をエスケープするように修正しました。