### PR TITLE
Adjusted dotrc creation process

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -63,6 +63,8 @@ hrule="$( printf '%*s\n' "$columns" '' | tr ' ' - )"
 # tput {{{
 
 tp_bold="$(tput bold)"
+tp_green=$(tput setaf 2)
+tp_red=$(tput setaf 1)
 tp_reset="$(tput sgr0)"
 
 #}}}
@@ -122,6 +124,14 @@ prmpt() { #{{{
 
 bd_() { #{{{
   echo "${tp_bold}$@${tp_reset}"
+} #}}}
+
+rd_() { #{{{
+  echo "${tp_red}$@${tp_reset}"
+} #}}}
+
+grn_() { #{{{
+  echo "${tp_green}$@${tp_reset}"  
 } #}}}
 
 cleanup_namespace() { #{{{

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -136,7 +136,7 @@ grn_() { #{{{
 
 cleanup_namespace() { #{{{
   unset -f dotbundle get_fullpath path_without_home path_without_dotdir
-  unset -f __confirm prmpt bd_ dot_usage parse_linkfiles $0
+  unset -f __confirm prmpt bd_ grn_ rd_ dot_usage parse_linkfiles $0
 } #}}}
 
 parse_linkfiles() { # {{{

--- a/lib/dot_config.sh
+++ b/lib/dot_config.sh
@@ -4,8 +4,12 @@ dot_config() {
   if [ ! -e "${dotrc}" ]; then
     echo "$(prmpt 1 error)$(bd_ ${dotrc}) doesn't exist."
     if __confirm y "make configuration file ? "; then
-      echo "cp ${DOT_SCRIPT_ROOTDIR}/examples/dotrc ${dotrc}"
+      printf "mkdir -p ${dotrc//dotrc} ... "
+      mkdir -p "${dotrc//dotrc}"
+      if [ -d "${dotrc//dotrc}" ]; then echo "$(grn_ Success.)"; else echo "$(rd_ Failure. Aborted.)"; return 1; fi
+      printf "cp ${DOT_SCRIPT_ROOTDIR}/examples/dotrc ${dotrc} ... "
       cp "${DOT_SCRIPT_ROOTDIR}/examples/dotrc" "${dotrc}"
+      if [ -e "${dotrc}" ]; then echo "$(grn_ Success.)"; else echo "$(rd_ Failure. Aborted.)"; return 1; fi
     else
       echo "Aborted."; return 1
     fi


### PR DESCRIPTION
I noticed on my systems (all Fedora 30) that the `dotrc` creation is bugged and fails because it does not create the `~/.config/dot` directory, and therefore cannot copy the example `dotrc` to `~/.config/dot/dotrc`. 

I added two functions and variables to `common.sh`:
- `tp_green` and `tp_red`: similarly to tp_bold, these change the foreground colors to green and red, respectively, through `tput setaf #`.
- `grn_` and `rd_`: again, similarly to `bd_`, these can be quickly used to adjust `echo` text and then reset to defaults, all through `tput`.

In `dot_config.sh`, I adjusted the process for copying the `dotrc` file. In the original process, the script would `echo` the command that was to be executed before proceeding to execute it. 
I have adjusted this to use `printf` to allow the newline to be dropped, then used the newly created functions mentioned above to clearly show the outcome of the command. In between, I added a couple `if` statements to test for the file and directory, and abort in the case of any failures.